### PR TITLE
add simple repository clone plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ocurrent
 dist 
 docy
 styles.css
+example/ocaml/ocaml

--- a/current-sesame.opam
+++ b/current-sesame.opam
@@ -24,6 +24,7 @@ depends: [
   "current" {>= "0.4"}
   "cohttp-lwt" {>= "4.0.0"}
   "base64" {>= "3.5.0"}
+  "current_git"
   "alcotest" {with-test}
   "bos" {with-test}
   "odoc" {with-doc}

--- a/current-sesame.opam
+++ b/current-sesame.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.7"}
   "irmin-watcher" {>= "0.4.1"}
   "sesame" {= version}
-  "dream" {>= "~dev"}
+  "dream" {>= "1.0.0~alpha2"}
   "ppx_deriving_yaml" {>= "0.1.0" & with-test}
   "alcotest-lwt" {>= "1.3.0" & with-test}
   "yojson" {>= "1.7.0"}
@@ -44,3 +44,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/patricoferris/sesame.git"
+pin-depends: [
+  ["graphql_ppx.dev" "git+https://github.com/reasonml-community/graphql-ppx"]
+]

--- a/current-sesame.opam.template
+++ b/current-sesame.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["graphql_ppx.dev" "git+https://github.com/reasonml-community/graphql-ppx"]
+]

--- a/current_sesame/github/dune
+++ b/current_sesame/github/dune
@@ -3,10 +3,22 @@
 (library
  (name github)
  (public_name current-sesame.github)
- (libraries cohttp-lwt current.cache base64 ptime yojson fmt logs)
+ (libraries
+  cohttp-lwt
+  current.cache
+  current_git
+  base64
+  ptime
+  yojson
+  fmt
+  logs)
  (preprocess
-  (pps ppx_deriving_yojson graphql_ppx -- -schema
-    current_sesame/github/schema.json))
+  (pps
+   ppx_deriving_yojson
+   graphql_ppx
+   --
+   -schema
+   current_sesame/github/schema.json))
  (preprocessor_deps
   (file schema.json)))
 

--- a/current_sesame/github/github.ml
+++ b/current_sesame/github/github.ml
@@ -1,2 +1,3 @@
 module Graphql = Graphql
 module Api = Api
+module Repository = Repository

--- a/current_sesame/github/graphql.mli
+++ b/current_sesame/github/graphql.mli
@@ -3,7 +3,7 @@ module Date : sig
 
   val parse : Yojson.Basic.t -> t
 
-  val serialisize : t -> Yojson.Basic.t
+  val serialize : t -> Yojson.Basic.t
 end
 
 module Url : sig
@@ -11,7 +11,7 @@ module Url : sig
 
   val parse : Yojson.Basic.t -> t
 
-  val serialisize : t -> Yojson.Basic.t
+  val serialize : t -> Yojson.Basic.t
 end
 
 type 'a res = ('a, [ `Msg of string ]) result
@@ -28,11 +28,9 @@ type conf = {
 module Make (C : Cohttp_lwt.S.Client) : sig
   val run_query :
     conf:conf ->
-    < parse : Yojson.Basic.t -> 'a
-    ; query : string
-    ; variables : Yojson.Basic.t
-    ; .. > ->
-    'a res Lwt.t
+    parse:(Yojson.Basic.t -> 'a) ->
+    query:string ->
+    Yojson.Basic.t -> ('a, [> `Msg of string ]) result Lwt.t
 
   module FileContentQuery : sig
     val get :

--- a/current_sesame/github/repository.ml
+++ b/current_sesame/github/repository.ml
@@ -1,0 +1,83 @@
+(* Largely copied from the docker base images implementation 
+   https://github.com/ocurrent/docker-base-images/blob/master/src/git_repositories.ml *)
+
+open Lwt.Infix
+open Current.Syntax
+
+let ( >>!= ) x f = x >>= function Ok y -> f y | Error _ as e -> Lwt.return e
+
+module Builder = struct
+  type t = No_context
+
+  let id = "repository"
+
+  module Key = struct
+    type t = { name : string; repo : string; branch : string; dest : Fpath.t }
+
+    let digest { name; repo; branch; dest } =
+      let json =
+        `Assoc
+          [
+            ("name", `String name);
+            ("repo", `String repo);
+            ("branch", `String branch);
+            ("dest", `String (Fpath.to_string dest));
+          ]
+      in
+      Yojson.Safe.to_string json
+  end
+
+  module Value = struct
+    type t = { name : string; hash : string; dir : string } [@@deriving yojson]
+
+    let marshal t = to_yojson t |> Yojson.Safe.to_string
+
+    let unmarshal s =
+      match Yojson.Safe.from_string s |> of_yojson with
+      | Ok x -> x
+      | Error _ -> failwith "failed to parse git repository value"
+  end
+
+  let get_commit_hash ~job ~repo ~branch dest =
+    (* Re-use ocurrent's disk store... maybe not the best idea *)
+    let store =
+      Fpath.(v (Filename.concat (Sys.getcwd ()) "var") / "sesame-data")
+    in
+    let data = Fpath.(store // dest) in
+    Current.Process.with_tmpdir (fun cwd ->
+        Current.Process.exec ~cwd ~cancellable:true ~job
+          ("", [| "git"; "clone"; "-b"; branch; repo; "." |])
+        >>!= fun () ->
+        Current.Process.exec ~cwd ~cancellable:true ~job
+          ("", [| "mkdir"; "-p"; Fpath.(to_string store) |])
+        >>!= fun () ->
+        Current.Process.exec ~cwd ~cancellable:true ~job
+          ("", [| "rsync"; "-avq"; "."; Fpath.(to_string data) |])
+        >>!= fun () ->
+        Current.Process.check_output ~cwd ~cancellable:true ~job
+          ("", [| "git"; "rev-parse"; "HEAD" |])
+        >>!= fun hash -> Lwt.return (Ok (String.trim hash, data)))
+
+  let build No_context job { Key.name; repo; branch; dest } =
+    Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
+    get_commit_hash ~job ~repo ~branch dest >>!= fun (hash, dir) ->
+    Lwt.return (Ok { Value.name; hash; dir = Fpath.to_string dir })
+
+  let pp ppf t = Fmt.pf ppf "Git repo: %s from %s" t.Key.name t.repo
+
+  let auto_cancel = true
+end
+
+module Cache = Current_cache.Make (Builder)
+
+type t = { name : string; commit_id : Current_git.Commit_id.t; dir : string }
+
+let v ~name ~repo ~branch dest = Builder.Key.{ name; repo; branch; dest }
+
+let clone ?(gref = "main") ?schedule key =
+  let+ { Builder.Value.name; hash; dir } =
+    Current.component "Fetching %s" key.Builder.Key.name
+    |> let> key = Current.return key in
+       Cache.get ?schedule Builder.No_context key
+  in
+  { name; commit_id = Current_git.Commit_id.v ~repo:key.repo ~gref ~hash; dir }

--- a/current_sesame/github/repository.mli
+++ b/current_sesame/github/repository.mli
@@ -1,0 +1,19 @@
+module Builder : Current_cache.S.BUILDER
+
+type t = { name : string; commit_id : Current_git.Commit_id.t; dir : string }
+(** The result of cloning a repository passing through the [name], returning the
+    commit id and most importantly the absolute path to the checked out
+    repository *)
+
+val v : name:string -> repo:string -> branch:string -> Fpath.t -> Builder.Key.t
+(** [v ~name ~repo ~branch dir] generate a new builder key to pass to the
+    {!clone} function *)
+
+val clone :
+  ?gref:string ->
+  ?schedule:Current_cache.Schedule.t ->
+  Builder.Key.t ->
+  t Current.t
+(** [clone key] will clone the repositoy specified by [key] into the directory
+    also specified by [key], to access the data from the repository use the
+    [dir] in the result of this function as it contains the path to the data. *)

--- a/current_sesame/server.ml
+++ b/current_sesame/server.ml
@@ -67,7 +67,7 @@ let dev_server ~port ~reload dir =
                  | Some _ ->
                      Lwt_condition.wait reload >>= fun _ ->
                      Lwt_unix.sleep 0.2 >>= fun _ ->
-                     Dream.send websocket "RELOAD" >>= fun () ->
+                     Dream.send "RELOAD" websocket >>= fun () ->
                      Dream.close_websocket websocket
                  | _ -> Dream.close_websocket websocket));
          Dream.get "/**" (static ~port dir);

--- a/current_sesame/server.ml
+++ b/current_sesame/server.ml
@@ -67,7 +67,7 @@ let dev_server ~port ~reload dir =
                  | Some _ ->
                      Lwt_condition.wait reload >>= fun _ ->
                      Lwt_unix.sleep 0.2 >>= fun _ ->
-                     Dream.send "RELOAD" websocket >>= fun () ->
+                     Dream.send websocket "RELOAD" >>= fun () ->
                      Dream.close_websocket websocket
                  | _ -> Dream.close_websocket websocket));
          Dream.get "/**" (static ~port dir);

--- a/dune-project
+++ b/dune-project
@@ -1,53 +1,99 @@
 (lang dune 2.7)
+
 (name sesame)
+
 (generate_opam_files true)
-(source (github patricoferris/sesame))
+
+(source
+ (github patricoferris/sesame))
+
 (license ISC)
+
 (authors "Patrick Ferris")
+
 (maintainers "pf341@patricoferris.com")
+
 (package
  (name sesame)
  (synopsis "A Simple Static Site Generator")
  (description
   "Sesame can build simple static sites from Jeykll-format documents")
  (depends
-  (alcotest-lwt (and (>= 1.3.0) :with-test))
-  (ppx_deriving_yojson (>= 3.6.1))
-  (digestif (>= 1.0.0))
-  (yaml (>= 2.1.0))
-  (uri (>= 4.1.0))
-  (tyxml-ppx (>= 4.4.0))
-  (tyxml (>= 4.4.0))
-  (ppx_deriving_yaml (>= 0.1.0))
-  (omd (>= 2.0.0~alpha1))
-  (lwt (>= 5.4.0))
-  (jekyll-format (>= 0.2.0))
-  (fpath (>= 0.7.3))
-  (fmt (>= 0.8.9))
-  (cohttp-lwt-unix (>= 4.0.0))
-  (cohttp (>= 4.0.0))
-  (camlimages (>= 5.0.4))
+  (alcotest-lwt
+   (and
+    (>= 1.3.0)
+    :with-test))
+  (ppx_deriving_yojson
+   (>= 3.6.1))
+  (digestif
+   (>= 1.0.0))
+  (yaml
+   (>= 2.1.0))
+  (uri
+   (>= 4.1.0))
+  (tyxml-ppx
+   (>= 4.4.0))
+  (tyxml
+   (>= 4.4.0))
+  (ppx_deriving_yaml
+   (>= 0.1.0))
+  (omd
+   (>= 2.0.0~alpha1))
+  (lwt
+   (>= 5.4.0))
+  (jekyll-format
+   (>= 0.2.0))
+  (fpath
+   (>= 0.7.3))
+  (fmt
+   (>= 0.8.9))
+  (cohttp-lwt-unix
+   (>= 4.0.0))
+  (cohttp
+   (>= 4.0.0))
+  (camlimages
+   (>= 5.0.4))
   (alcotest :with-test)
   bos))
+
 (package
  (name current-sesame)
  (synopsis "The OCurrent-powered Static Site Generator")
  (description
   "Current-sesame builds on top of Sesame providing a toolkit of OCurrent-powered modules for building more complex pipelines that ultimately build websites")
  (depends
-  (irmin-watcher (>= 0.4.1))
-  (sesame (= :version))
-  (dream (>= ~dev))
-  (ppx_deriving_yaml (and (>= 0.1.0) :with-test))
-  (alcotest-lwt (and (>= 1.3.0) :with-test))
-  (yojson (>= 1.7.0))
-  (ptime (>= 0.8.5))
-  (ppx_deriving_yojson (>= 3.6.1))
-  (logs (>= 0.7.0))
-  (graphql_ppx (>= 1.0.1))
-  (fmt (>= 0.8.9))
-  (current (>= 0.4))
-  (cohttp-lwt (>= 4.0.0))
-  (base64 (>= 3.5.0))
+  (irmin-watcher
+   (>= 0.4.1))
+  (sesame
+   (= :version))
+  (dream
+   (>= ~dev))
+  (ppx_deriving_yaml
+   (and
+    (>= 0.1.0)
+    :with-test))
+  (alcotest-lwt
+   (and
+    (>= 1.3.0)
+    :with-test))
+  (yojson
+   (>= 1.7.0))
+  (ptime
+   (>= 0.8.5))
+  (ppx_deriving_yojson
+   (>= 3.6.1))
+  (logs
+   (>= 0.7.0))
+  (graphql_ppx
+   (>= 1.0.1))
+  (fmt
+   (>= 0.8.9))
+  (current
+   (>= 0.4))
+  (cohttp-lwt
+   (>= 4.0.0))
+  (base64
+   (>= 3.5.0))
+  current_git
   (alcotest :with-test)
   (bos :with-test)))

--- a/dune-project
+++ b/dune-project
@@ -67,7 +67,7 @@
   (sesame
    (= :version))
   (dream
-   (>= ~dev))
+   (>= 1.0.0~alpha2))
   (ppx_deriving_yaml
    (and
     (>= 0.1.0)

--- a/example/ocaml/dune
+++ b/example/ocaml/dune
@@ -4,4 +4,4 @@
  (preprocess
   (pps ppx_deriving_yaml tyxml-ppx)))
 
-(data_only_dirs ocaml)
+(data_only_dirs ocaml var)

--- a/example/ocaml/dune
+++ b/example/ocaml/dune
@@ -3,3 +3,5 @@
  (libraries sesame current_web current_sesame current-sesame.github)
  (preprocess
   (pps ppx_deriving_yaml tyxml-ppx)))
+
+(data_only_dirs ocaml)

--- a/example/ocaml/main.ml
+++ b/example/ocaml/main.ml
@@ -84,8 +84,19 @@ let copy ~src ~dst =
   Current.all_labelled ws
 
 let pipeline ~token () =
+  let repo =
+    Bos.OS.Dir.create @@ Fpath.v "ocaml" |> ignore;
+    Current.map (fun _ -> ())
+    @@ Github.Repository.(
+         clone
+           ~schedule:
+             (Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) ())
+           (v ~name:"OCaml" ~branch:"trunk" ~repo:"git://github.com/ocaml/ocaml"
+              (Fpath.v "ocaml")))
+  in
   Current.all
     [
+      repo;
       tutorials ~src:(Fpath.v "data/tutorials")
         ~dst:Fpath.(v "ocaml.org" / Conf.tutorial_dir);
       pages token;


### PR DESCRIPTION
This PR adds a simple repository clone ocurrent plugin, it relies a little on the internal details of ocurrent, in particular the location of the `disk_store` (cwd + "var") which is where the plugin rsyncs the clone, but seems to work for my purposes :)

You now be able to specify a repo to clone into your project and use it as a data source from the file-system, the benefits of this approach is that you can monitor the Github repository as before and the rsync into the directory will trigger the file watcher which will rebuild the relevant pages. I haven't tested that but it *should* work...  