### PR TITLE
add simple dream serve

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version=0.15.0
+version=0.18.0
 parse-docstrings=true

--- a/current_sesame/dream/current_dream.ml
+++ b/current_sesame/dream/current_dream.ml
@@ -1,0 +1,31 @@
+(* Simple OCurrent wrapper for Dream.serve *)
+
+module Serve = struct
+  type t = Dream.handler
+
+  let auto_cancel = true
+  let id = "current-dream.html"
+
+  module Key = Current.Unit
+
+  module Value = Current.Unit
+
+  let build handler job () = 
+    let open Lwt.Infix in 
+    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+    Lwt_result.ok @@ Dream.serve handler
+  let pp ppf _ = Fmt.string ppf "Starting dream server"
+end
+
+module Raw = struct
+  module SC = Current_cache.Make (Serve)
+
+  let serve handler () = SC.get handler ()
+end
+
+open Current.Syntax
+
+let serve contents =
+  Current.component "dream-serve"
+  |> let> contents = contents in
+     Raw.serve contents ()

--- a/current_sesame/dream/current_dream.ml
+++ b/current_sesame/dream/current_dream.ml
@@ -4,16 +4,17 @@ module Serve = struct
   type t = Dream.handler
 
   let auto_cancel = true
+
   let id = "current-dream.html"
 
   module Key = Current.Unit
-
   module Value = Current.Unit
 
-  let build handler job () = 
-    let open Lwt.Infix in 
+  let build handler job () =
+    let open Lwt.Infix in
     Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
     Lwt_result.ok @@ Dream.serve handler
+
   let pp ppf _ = Fmt.string ppf "Starting dream server"
 end
 

--- a/current_sesame/dream/dune
+++ b/current_sesame/dream/dune
@@ -1,0 +1,4 @@
+(library
+ (name current_dream)
+ (public_name current-sesame.dream)
+ (libraries current.cache dream))

--- a/current_sesame/github/graphql.ml
+++ b/current_sesame/github/graphql.ml
@@ -1,5 +1,4 @@
-open Lwt.Infix
-[@warning "-32"]
+open Lwt.Infix [@warning "-32"]
 
 module Date = struct
   type t = Ptime.t
@@ -47,9 +46,7 @@ module Make (C : Cohttp_lwt.S.Client) = struct
   let run_query ~conf ~parse ~query variables =
     let uri = Uri.of_string "https://api.github.com/graphql" in
     let headers = make_headers ~conf in
-    let body =
-      `Assoc [ ("query", `String query); ("variables", variables) ]
-    in
+    let body = `Assoc [ ("query", `String query); ("variables", variables) ] in
     let body = `String (Yojson.Basic.to_string body) in
     C.post ~headers ~body uri >>= fun (resp, body) ->
     Cohttp_lwt.Body.to_string body >|= fun body ->
@@ -67,7 +64,7 @@ module Make (C : Cohttp_lwt.S.Client) = struct
         with
         | Failure err -> Error (`Msg err)
         | Yojson.Json_error err -> Error (`Msg err)
-        | Yojson.Basic.Util.Type_error (err, _) -> Error (`Msg err) )
+        | Yojson.Basic.Util.Type_error (err, _) -> Error (`Msg err))
 
   module FileContentQuery = struct
     module Q =
@@ -84,14 +81,15 @@ module Make (C : Cohttp_lwt.S.Client) = struct
       }
     |}]
 
-    let get ~conf ~branch file = 
+    let get ~conf ~branch file =
       run_query ~conf ~parse:Q.unsafe_fromJson ~query:Q.query
       @@ (Q.makeVariables ~owner:conf.owner ~repo:conf.repo
-           ~file:(Fmt.str "%s:%s" branch file)
-           () |> Q.serializeVariables |> Q.variablesToJson)
+            ~file:(Fmt.str "%s:%s" branch file)
+            ()
+         |> Q.serializeVariables |> Q.variablesToJson)
       >>= function
       | Ok response -> (
-        let response = Q.parse response in 
+          let response = Q.parse response in
           match response.repository with
           | Some repo -> (
               match repo.file with
@@ -99,8 +97,8 @@ module Make (C : Cohttp_lwt.S.Client) = struct
               | Some (`UnspecifiedFragment b) ->
                   Lwt.return
                     (Error (`Msg (Fmt.str "Unspecified Fragment %s" b)))
-              | None -> Lwt_result.return None )
-          | None -> Lwt.return (Ok None) )
+              | None -> Lwt_result.return None)
+          | None -> Lwt.return (Ok None))
       | Error e -> Lwt.return (Error e)
   end
   [@warning "-32"]
@@ -121,17 +119,18 @@ module Make (C : Cohttp_lwt.S.Client) = struct
     let get ~conf ~branch file =
       run_query ~conf ~parse:Q.unsafe_fromJson ~query:Q.query
       @@ (Q.makeVariables ~owner:conf.owner ~repo:conf.repo
-           ~file:(Fmt.str "%s:%s" branch file)
-           () |> Q.serializeVariables |> Q.variablesToJson)
+            ~file:(Fmt.str "%s:%s" branch file)
+            ()
+         |> Q.serializeVariables |> Q.variablesToJson)
       >>= function
       | Ok response -> (
-        let response = Q.parse response in
+          let response = Q.parse response in
           match response.repository with
           | Some repo -> (
               match repo.file with
               | Some s -> Lwt.return (Ok (Some s.id))
-              | None -> Lwt_result.return None )
-          | None -> Lwt.return (Ok None) )
+              | None -> Lwt_result.return None)
+          | None -> Lwt.return (Ok None))
       | Error e -> Lwt.return (Error e)
   end
   [@warning "-32"]
@@ -152,10 +151,12 @@ module Make (C : Cohttp_lwt.S.Client) = struct
     }|}]
 
     let get ~conf =
-      run_query ~conf ~parse:Q.unsafe_fromJson ~query:Q.query @@ (Q.makeVariables ~owner:conf.owner ~repo:conf.repo () |> Q.serializeVariables |> Q.variablesToJson)
+      run_query ~conf ~parse:Q.unsafe_fromJson ~query:Q.query
+      @@ (Q.makeVariables ~owner:conf.owner ~repo:conf.repo ()
+         |> Q.serializeVariables |> Q.variablesToJson)
       >>= function
       | Ok response -> (
-        let response = Q.parse response in 
+          let response = Q.parse response in
           match response.repository with
           | Some repo -> (
               match repo.tree with
@@ -167,12 +168,12 @@ module Make (C : Cohttp_lwt.S.Client) = struct
                         (Ok
                            (Array.map
                               (fun t -> { Api.Files.name = t.Q.name })
-                              arr)) )
+                              arr)))
               | Some (`UnspecifiedFragment b) ->
                   Lwt.return
                     (Error (`Msg (Fmt.str "Unspecified Fragment %s" b)))
-              | None -> Lwt_result.return [||] )
-          | None -> Lwt.return (Ok [||]) )
+              | None -> Lwt_result.return [||])
+          | None -> Lwt.return (Ok [||]))
       | Error e -> Lwt.return (Error e)
   end
   [@warning "-32"]
@@ -202,10 +203,12 @@ module Make (C : Cohttp_lwt.S.Client) = struct
 
     let get ~conf =
       let ( >>!= ) = Option.bind in
-      run_query ~conf ~parse:Q.unsafe_fromJson ~query:Q.query @@ (Q.makeVariables ~owner:conf.owner ~repo:conf.repo () |> Q.serializeVariables |> Q.variablesToJson)
+      run_query ~conf ~parse:Q.unsafe_fromJson ~query:Q.query
+      @@ (Q.makeVariables ~owner:conf.owner ~repo:conf.repo ()
+         |> Q.serializeVariables |> Q.variablesToJson)
       >>= function
       | Ok response ->
-        let response = Q.parse response in 
+          let response = Q.parse response in
           let resp =
             response.repository >>!= fun repo ->
             repo.refs >>!= fun refs ->

--- a/current_sesame/github/graphql.mli
+++ b/current_sesame/github/graphql.mli
@@ -30,7 +30,8 @@ module Make (C : Cohttp_lwt.S.Client) : sig
     conf:conf ->
     parse:(Yojson.Basic.t -> 'a) ->
     query:string ->
-    Yojson.Basic.t -> ('a, [> `Msg of string ]) result Lwt.t
+    Yojson.Basic.t ->
+    ('a, [> `Msg of string ]) result Lwt.t
 
   module FileContentQuery : sig
     val get :

--- a/current_sesame/local.ml
+++ b/current_sesame/local.ml
@@ -25,7 +25,7 @@ let save_list lst =
                   | Ok () ->
                       Log.info (fun f -> f "Updated %a" Fpath.pp path);
                       (Ok (), None)
-                  | Error _ as e -> (e, None) ))
+                  | Error _ as e -> (e, None)))
             paths
         |> fun _ -> (Ok (), None) )
 

--- a/current_sesame/server.ml
+++ b/current_sesame/server.ml
@@ -36,7 +36,7 @@ let static ~port local_root request =
       | None -> (
           match Dream.path request with
           | [] | [ "/" ] | [ "" ] -> aux ~once:true (Some "index.html")
-          | _ -> Dream.respond ~status:`Not_Found "" )
+          | _ -> Dream.respond ~status:`Not_Found "")
       | Some path -> (
           loader ~port local_root path request >>= fun response ->
           match Dream.status response with
@@ -53,7 +53,7 @@ let static ~port local_root request =
               else
                 aux ~once:true
                   (validate_path (Dream.path request @ [ "index.html" ]))
-          | _ -> Lwt.return response )
+          | _ -> Lwt.return response)
     in
     aux (validate_path (Dream.path request))
 

--- a/current_sesame/watcher.ml
+++ b/current_sesame/watcher.ml
@@ -22,6 +22,12 @@ let job_id ~path watcher =
 module FS = struct
   open Lwt.Infix
 
+  type t = { 
+    f : unit -> unit Lwt.t;
+    cond : unit Lwt_condition.t;
+    unwatch : unit -> unit Lwt.t;
+  }
+
   let run_job ~watcher ~engine ~dir path =
     let path = Fpath.(v dir // path) in
     Hashtbl.iter (fun k _ -> print_endline (Fpath.to_string k)) watcher;
@@ -53,7 +59,7 @@ module FS = struct
       in
       aux ()
     in
-    (f, cond, unwatch)
+    { f; cond; unwatch }
 end
 
 module Js = struct

--- a/example/ocaml/components.ml
+++ b/example/ocaml/components.ml
@@ -111,7 +111,7 @@ type panel_item = {
 let panel ~title items =
   nav
     ~a:[ a_class [ "panel" ] ]
-    ( [ p ~a:[ a_class [ "panel-heading" ] ] [ txt title ] ]
+    ([ p ~a:[ a_class [ "panel-heading" ] ] [ txt title ] ]
     @ List.map
         (fun { link; icon; text } ->
           a
@@ -126,7 +126,7 @@ let panel ~title items =
                 ];
               text;
             ])
-        items )
+        items)
 
 let centred_section content =
   Html.section

--- a/example/ocaml/main.ml
+++ b/example/ocaml/main.ml
@@ -111,18 +111,18 @@ let run dev =
   let engine = Current.Engine.create (pipeline ~token) in
   let f =
     Lwt.map
-      (fun (f, cond, _) -> (f, cond))
+      (fun Current_sesame.Watcher.FS.{ f; cond; _ } -> (f, cond))
       (Current_sesame.Watcher.FS.watch ~watcher ~engine "data")
   in
   let routes = Current_web.routes engine in
   let site = Current_web.Site.v ~name:"OCaml.org Builder" ~has_role routes in
   Lwt_main.run
     (Lwt.choose
-       ( [
-           Current.Engine.thread engine;
-           Current_web.run ~mode:(`TCP (`Port 8081)) site;
-           Lwt_result.ok @@ Lwt.bind f (fun (f, _) -> f ());
-         ]
+       ([
+          Current.Engine.thread engine;
+          Current_web.run ~mode:(`TCP (`Port 8081)) site;
+          Lwt_result.ok @@ Lwt.bind f (fun (f, _) -> f ());
+        ]
        @
        if dev then
          [
@@ -131,7 +131,7 @@ let run dev =
                   Current_sesame.Server.dev_server ~port:8082 ~reload
                     "./ocaml.org");
          ]
-       else [] ))
+       else []))
 
 open Cmdliner
 

--- a/example/ocaml/page.ml
+++ b/example/ocaml/page.ml
@@ -142,8 +142,7 @@ module H = struct
                             ~a:[ a_class [ "has-text-grey" ] ]
                             [
                               txt
-                                (Fmt.str "(%a)" (Ptime.pp_human ())
-                                   x.created_at);
+                                (Fmt.str "(%a)" (Ptime.pp_human ()) x.created_at);
                             ];
                         ];
                     icon = "fa-box-open";

--- a/example/ocaml/tutorial.ml
+++ b/example/ocaml/tutorial.ml
@@ -87,8 +87,8 @@ module Index = struct
                                 Fpath.(
                                   v "/" / Conf.tutorial_dir
                                   / Fpath.filename
-                                      ( Sesame.Utils.filename_to_html
-                                      @@ Fpath.v t.path ))
+                                      (Sesame.Utils.filename_to_html
+                                     @@ Fpath.v t.path))
                               in
                               li
                                 ~a:[ a_style "list-style: none" ]

--- a/lib/collection.ml
+++ b/lib/collection.ml
@@ -32,7 +32,7 @@ module Make (M : Meta) = struct
         match M.of_yaml Jf.(fields_to_yaml (fields data)) with
         | Ok meta ->
             Ok { path = Fpath.to_string file; meta; body = Jf.body data }
-        | Error (`Msg m) -> Error (`Msg m) )
+        | Error (`Msg m) -> Error (`Msg m))
     | Error (`Msg m) -> Error (`Msg m)
 
   let build file =

--- a/lib/image.ml
+++ b/lib/image.ml
@@ -43,8 +43,8 @@ let encode t =
         ( "image",
           (* Hashing the image contents... ? *)
           `String
-            ( Bytes.to_string t.image#dump
-            |> Digestif.SHA1.digest_string |> Digestif.SHA1.to_raw_string ) );
+            (Bytes.to_string t.image#dump
+            |> Digestif.SHA1.digest_string |> Digestif.SHA1.to_raw_string) );
       ]
   in
   Fmt.str "%a" Yaml.pp yaml

--- a/lib/transformer.ml
+++ b/lib/transformer.ml
@@ -17,8 +17,8 @@ module Toc = struct
           | Omd.Heading (s, il) -> (
               match il.il_desc with
               | Omd.Text heading -> loop (H (s, heading) :: acc) bs
-              | _ -> loop acc bs )
-          | _ -> loop acc bs )
+              | _ -> loop acc bs)
+          | _ -> loop acc bs)
     in
     loop [] doc
 
@@ -33,7 +33,7 @@ module Toc = struct
                 bl_attributes =
                   ("id", Utils.title_to_dirname heading) :: b.bl_attributes;
               }
-          | _ -> b )
+          | _ -> b)
       | _ -> b
     in
     List.map f doc
@@ -73,14 +73,14 @@ module Toc = struct
           let (Br (p, lst)) = arr.(x - 1) in
           if x = y then (
             arr.(x - 1) <- Br (p, lst @ [ Br (a, []) ]);
-            aux x (b :: xs) )
+            aux x (b :: xs))
           else if x > y then (
             arr.(x) <- Br (a, []);
             tidy arr (y - 1) x;
-            aux x (b :: xs) )
+            aux x (b :: xs))
           else (
             arr.(x) <- Br (a, []);
-            aux x (b :: xs) )
+            aux x (b :: xs))
     in
     aux 0 lst
 
@@ -107,8 +107,8 @@ module Toc = struct
     | Br (v, lst) ->
         [%html
           "<ul class='toc'><li>"
-            ( map_to_item v
-            @ List.fold_left (fun acc v -> acc @ [ preorder v ]) [] lst )
+            (map_to_item v
+            @ List.fold_left (fun acc v -> acc @ [ preorder v ]) [] lst)
             "</li></ul>"]
 
   let pp ppf t =
@@ -125,11 +125,11 @@ module Toc = struct
     | _ -> assert true
 
   let to_html toc =
-    ( try accessibility toc
-      with Failure t ->
-        print_endline "== Failed Heading List ==";
-        pp Format.std_formatter toc;
-        raise (Failure t) );
+    (try accessibility toc
+     with Failure t ->
+       print_endline "== Failed Heading List ==";
+       pp Format.std_formatter toc;
+       raise (Failure t));
     let tree = to_tree toc in
     preorder tree |> fun list ->
     [%html
@@ -170,7 +170,7 @@ module Image = struct
                 b with
                 bl_desc = Omd.Paragraph { il with il_desc = make_img img };
               }
-          | _ -> b )
+          | _ -> b)
       | _ -> b
     in
     List.map f blocks

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -15,7 +15,7 @@ let rec html_path ?(dir = None) path =
       | _ :: rst ->
           html_path ~dir:None
             (List.fold_left (fun acc seg -> Fpath.(acc / seg)) t rst)
-      | _ -> failwith "Error" )
+      | _ -> failwith "Error")
 
 let filename_to_html path =
   let path = Fpath.filename path |> Fpath.v in


### PR DESCRIPTION
I've been copying this little dream wrapper around so thought it could live in `current_sesame` instead seeing as there is a dependency on dream anyway. It allows you to add a **never returning** `unit Current.t` i.e. the server. This is nice to feed data into the server as an OCurrent pipeline: 

<img width="1165" alt="Screenshot 2021-06-17 at 17 19 33" src="https://user-images.githubusercontent.com/20166594/122435775-31a3f100-cf90-11eb-8e8d-d7208d87b14b.png">

An example pipeline all feeding into the final server 