### PR TITLE
update omd dependency

### DIFF
--- a/example/simple-sesame/main.ml
+++ b/example/simple-sesame/main.ml
@@ -17,7 +17,7 @@ module H = struct
       ]
     in
     Sesame.Components.html ~lang:"en" ~css:"/styles" ~title:t.meta.title
-      ~description:"home page" ~body
+      ~description:"home page" ~body ()
     |> Fmt.str "%a" (Tyxml.Html.pp ())
     |> Lwt_result.return
 end

--- a/lib/collection.ml
+++ b/lib/collection.ml
@@ -65,7 +65,7 @@ module Html (M : Meta) = struct
       ]
     in
     Components.html ~lang:"en" ~css:"/styles" ~title:"Main"
-      ~description:"home page" ~body
+      ~description:"home page" ~body ()
     |> fun html ->
     { path = t.path; html = Fmt.str "%a" (Tyxml.Html.pp ()) html }
     |> Lwt_result.return

--- a/lib/components.ml
+++ b/lib/components.ml
@@ -1,6 +1,6 @@
 open Tyxml
 
-let html ?(lang = "en") ?(css = "/styles") ~title ~description ~body =
+let html ?(lang = "en") ?(css = "/styles") ~title ~description ~body () =
   [%html {| 
     <!DOCTYPE html> 
     <html lang='|} lang {|'>


### PR DESCRIPTION
The AST for omd has been greatly simplified to remove most uses of records, this PR updates all of the Omd code to use this. At some point the internal TOC code could now also be removed in favour of the better one re-shipped with Omd. 